### PR TITLE
Only apply Subsite filter if model has SubsiteID Field

### DIFF
--- a/SubsiteAdminExtension.php
+++ b/SubsiteAdminExtension.php
@@ -5,7 +5,7 @@ class SubsiteAdminExtension extends DataExtension {
 	public function updateEditForm($form){
 		
 		$gridField = $form->Fields()->fieldByName($this->sanitiseClassNameExtension($this->owner->modelClass));
-		if(class_exists('Subsite')){
+		if(class_exists('Subsite') && singleton($this->owner->modelClass)->hasDatabaseField('SubsiteID')){
 			$list = $gridField->getList()->filter(array('SubsiteID'=>Subsite::currentSubsiteID()));
 			$gridField->setList($list);
 		}


### PR DESCRIPTION
This avoids an error when it tries to find the SubsiteID field that doesn't exist, but also allows some Models within a ModelAdmin to not have their objects attached to a particular subsite.

Uses a different solution than #1 